### PR TITLE
Show upcoming news on news card and news table view

### DIFF
--- a/TUM Campus App/News.swift
+++ b/TUM Campus App/News.swift
@@ -43,3 +43,9 @@ class News: ImageDownloader, DataElement {
     }
     
 }
+
+extension News: Equatable {
+    static func == (lhs: News, rhs: News) -> Bool {
+        return lhs.id == rhs.id
+    }
+}

--- a/TUM Campus App/NewsManager.swift
+++ b/TUM Campus App/NewsManager.swift
@@ -56,12 +56,14 @@ class NewsManager: Manager {
     }
     
     func handleNews(_ handler: ([DataElement]) -> ()) {
-        let items = NewsManager.news.sorted { (a, b) in
-            return a.date.compare(b.date as Date) == ComparisonResult.orderedDescending
-        }
         if single {
-            handler([getNextUpcomingNews()])
+            if let story = getNextUpcomingNews() {
+                handler([story])
+            }
         } else {
+            let items = NewsManager.news.sorted { (a, b) in
+                return a.date.compare(b.date as Date) == ComparisonResult.orderedDescending
+            }
             var returnableArray = [DataElement]()
             for item in items {
                 returnableArray.append(item)
@@ -70,14 +72,12 @@ class NewsManager: Manager {
         }
     }
     
-    func getNextUpcomingNews() -> News {
+    func getNextUpcomingNews() -> News? {
         let now = Date()
-        for (index, item) in NewsManager.news.enumerated() {
-            if item.date < now  {
-                return NewsManager.news[index-1]
-            }
+        if let firstStory = NewsManager.news.filter({ $0.date > now }).last ?? NewsManager.news.first {
+            return firstStory
         }
-        return NewsManager.news[0] // There are only past news
+        return nil
     }
     
     func getURL() -> String {

--- a/TUM Campus App/NewsManager.swift
+++ b/TUM Campus App/NewsManager.swift
@@ -60,9 +60,7 @@ class NewsManager: Manager {
             return a.date.compare(b.date as Date) == ComparisonResult.orderedDescending
         }
         if single {
-            if let firsStory = items.first {
-                handler([firsStory])
-            }
+            handler([getNextUpcomingNews()])
         } else {
             var returnableArray = [DataElement]()
             for item in items {

--- a/TUM Campus App/NewsManager.swift
+++ b/TUM Campus App/NewsManager.swift
@@ -72,6 +72,16 @@ class NewsManager: Manager {
         }
     }
     
+    func getNextUpcomingNews() -> News {
+        let now = Date()
+        for (index, item) in NewsManager.news.enumerated() {
+            if item.date < now  {
+                return NewsManager.news[index-1]
+            }
+        }
+        return NewsManager.news[0] // There are only past news
+    }
+    
     func getURL() -> String {
         return TumCabeApi.BaseURL.rawValue + TumCabeApi.News.rawValue
     }

--- a/TUM Campus App/NewsManager.swift
+++ b/TUM Campus App/NewsManager.swift
@@ -72,9 +72,9 @@ class NewsManager: Manager {
         }
     }
     
-    func getNextUpcomingNews() -> News? {
+    func getNextUpcomingNews(in news: [News] = NewsManager.news) -> News? {
         let now = Date()
-        if let firstStory = NewsManager.news.filter({ $0.date > now }).last ?? NewsManager.news.first {
+        if let firstStory = news.filter({ $0.date > now }).last ?? news.first {
             return firstStory
         }
         return nil

--- a/TUM Campus App/NewsTableViewController.swift
+++ b/TUM Campus App/NewsTableViewController.swift
@@ -37,6 +37,7 @@ extension NewsTableViewController {
         tableView.estimatedRowHeight = tableView.rowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.tableFooterView = UIView(frame: CGRect.zero)
+        tableView.scrollToRow(at: IndexPath(row: getNextUpcomingNewsRow(), section: 0), at: UITableViewScrollPosition.top, animated: false)
     }
     
 }
@@ -61,4 +62,14 @@ extension NewsTableViewController {
         news[indexPath.row].open()
     }
     
+}
+
+extension NewsTableViewController {
+    func getNextUpcomingNewsRow() -> Int {
+        if let nextNews = delegate?.dataManager().getNextUpcomingNews() as News? {
+            return news.index(of: nextNews) ?? 0
+        } else {
+            return 0
+        }
+    }
 }

--- a/TUM Campus App/NewsTableViewController.swift
+++ b/TUM Campus App/NewsTableViewController.swift
@@ -37,7 +37,9 @@ extension NewsTableViewController {
         tableView.estimatedRowHeight = tableView.rowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.tableFooterView = UIView(frame: CGRect.zero)
-        tableView.scrollToRow(at: IndexPath(row: getNextUpcomingNewsRow(), section: 0), at: UITableViewScrollPosition.top, animated: false)
+        if let index = getRowOfUpcomingNews() {
+            tableView.scrollToRow(at: IndexPath(row: index, section: 0), at: UITableViewScrollPosition.top, animated: true)
+        }
     }
     
 }
@@ -65,11 +67,10 @@ extension NewsTableViewController {
 }
 
 extension NewsTableViewController {
-    func getNextUpcomingNewsRow() -> Int {
+    func getRowOfUpcomingNews() -> Int? {
         if let nextNews = delegate?.dataManager().getNextUpcomingNews() as News? {
             return news.index(of: nextNews) ?? 0
-        } else {
-            return 0
         }
+        return nil
     }
 }

--- a/TUM Campus App/TumDataManager.swift
+++ b/TUM Campus App/TumDataManager.swift
@@ -131,11 +131,7 @@ class TumDataManager {
     }
     
     func getNextUpcomingNews() -> News? {
-        if let newsManager = managers[.NewsCollection] as? NewsManager {
-            return newsManager.getNextUpcomingNews()
-        } else {
-            return nil
-        }
+        return (managers[.NewsCollection] as? NewsManager)?.getNextUpcomingNews()
     }
     
     func getUserData() {

--- a/TUM Campus App/TumDataManager.swift
+++ b/TUM Campus App/TumDataManager.swift
@@ -130,6 +130,14 @@ class TumDataManager {
         managers[.NewsCollection]?.fetchData(receiver.receiveData)
     }
     
+    func getNextUpcomingNews() -> News? {
+        if let newsManager = managers[.NewsCollection] as? NewsManager {
+            return newsManager.getNextUpcomingNews()
+        } else {
+            return nil
+        }
+    }
+    
     func getUserData() {
         let handler = { (data: [DataElement]) in
             if let first = data.first as? UserData {


### PR DESCRIPTION
Before this PR, the newscard always displayed the newest story, now it displays the next upcoming story.
Also the collection view of all news (More>News) scrolls to the next upcoming story. This is inspired by the behaviour of the android app.

Closes #40 