### PR TITLE
Add a “Not Yet Implemented” alert

### DIFF
--- a/TUM Campus App/MoreTableViewController.swift
+++ b/TUM Campus App/MoreTableViewController.swift
@@ -75,6 +75,14 @@ extension MoreTableViewController {
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch indexPath.section {
+        case 2:
+            if indexPath.row == 1 {
+                handleNotYetImplemented()  // MVV
+            }
+        case 3:
+            if indexPath.row == 1 || indexPath.row == 2 {
+                handleNotYetImplemented()  // Services and Default Campus
+            }
         case 4:
             if let url =  URL(string: indexPath.row == 0 ? "https://tumcabe.in.tum.de/" : "mailto://tca-support.os.in@tum.de") {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
@@ -89,4 +97,12 @@ extension MoreTableViewController {
         }
     }
     
+}
+
+extension MoreTableViewController {
+    func handleNotYetImplemented() {
+        let alert = UIAlertController(title: "Not Yet Implemented!", message: "This feature will come soon. Stay tuned!", preferredStyle: UIAlertControllerStyle.alert)
+        alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler: nil))
+        self.present(alert, animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
When clicking on the following rows in the more view, a alert will be presented for the user:
- MVV
- Services
- Default Campus

![image](https://cloud.githubusercontent.com/assets/3121306/25074048/c245572e-22f3-11e7-95fa-8856288435fd.png)

This is meant as a quick and dirty fix so the user understand, why nothing happens. I prefer this solution over removing the items.

Related #70
