### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+**Everyone is able to contribute, we're happy to have you here!**
+
+Beside code contributions, you can also test our app and use the GitHub issue tracker to report bugs.
+
+### Workflow:
+- Master branch is protected, create PR's for your changes
+- Branch naming convention: `max/42-some-description`, where 42 is the issue number this branch is refering to
+- Create a separate PR for every feature/fix you're working on
+- Don't do any changes unrelated to your feature/fix to keep PR's easy to review
+- If the changes are a bigger feature, add it to the [release notes](https://github.com/TCA-Team/iOS/blob/master/fastlane/metadata/de-DE/release_notes.txt), located in `fastlane/metadata`
+
+If you are part of the official [GitHub iOS team](https://github.com/orgs/TCA-Team/teams/ios):
+- **Don't create PR's from your fork**, but rather directly create branches in this repository. The reason is, that our CI can do more stuff, when the PR is coming from an "inhouse"-branch
+
+### Continuous Integration
+- We use Travis to perform builds on new PR's
+- We have SonarQube to check the code quality at https://sonarqube.com/dashboard?id=de.tum.in.www.Tum-Campus-App
+- If a PR is coming from a branch from this repository (and not a fork), our @TCA-Bot will review the changes automatically
+- Use `[ci skip]` in the commit message if you know there is no need to run a build on Travis

--- a/README.md
+++ b/README.md
@@ -17,12 +17,8 @@ Features already implemented:
 * Cafeteria Information
 
 ## Contributing
-You're welcome to contribute to this app! Just check it out and open PR's for your contributions. 
-
-- We use [Travis](https://travis-ci.org/TCA-Team/iOS) to perform builds on new PR's
-- We have SonarQube to check the code quality at [https://sonarqube.com/dashboard?id=de.tum.in.www.Tum-Campus-App](https://sonarqube.com/dashboard?id=de.tum.in.www.Tum-Campus-App)
-- If a PR is coming from a branch from this repository (and not a fork), our [@TCA-Bot](https://travis-ci.org/TCA-Team/iOS) will review the changes automatically
-- Use [ci skip] in the commit message if you know there is no need to run a build on Travis
+You're welcome to contribute to this app!
+Check out our detailed information at [CONTIRBUTING.md](https://github.com/TCA-Team/iOS/blob/master/CONTRIBUTING.md)!
 
 ## Publishing a new version
 - You can use _fastlane snapshot_ to automatically generate localized screenshots. If you want to add a view, just record a UI Test and add it to the AutomatedScreenshots.swift test


### PR DESCRIPTION
This moves the current contributing guidelines from the README.md to CONTRIBUTING.md and adds some more guidelines.

See https://github.com/blog/1184-contributing-guidelines
<img width="980" alt="screen shot 2017-04-16 at 22 49 30" src="https://cloud.githubusercontent.com/assets/3121306/25074269/ad269e80-22f7-11e7-9b04-618adffb1098.png">
