### PR TITLE
#145 Remove `reset_simulators` build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ osx_image: xcode8.3
 
 branches:
   # Only run push builds for the master branch. PR builds are run nevertheless
-  only: 
+  only:
     - master
 
 before_install:
@@ -16,7 +16,6 @@ before_install:
   - ./fastlane/before_install.sh
 
 script:
-   - fastlane snapshot reset_simulators --force # Workaround for Travis bug https://github.com/travis-ci/travis-ci/issues/7031
    - ./fastlane/run.sh  # Decide which lane to run
 
 notifications:


### PR DESCRIPTION
### Issue
In Xcode-8.2 it was necessary to remove the simulators before running the test suite because of some simulators being duplicated. 
In Xcode-8.3 this bug seems to be fixed. Therefore our build times should decrease

This fixes the following issue(s): 
#145
