### PR TITLE
151 - Fix issues with wonky ID input

### DIFF
--- a/TUM Campus App/LoginViewController.swift
+++ b/TUM Campus App/LoginViewController.swift
@@ -76,8 +76,12 @@ extension LoginViewController: UITextFieldDelegate, TokenFetcherControllerDelega
         
         for i in textFieldIndex..<textFields.endIndex {
             let startIndex = mutableReplaced.startIndex
-            let endIndex = replaced.index(startIndex, offsetBy: min(mutableReplaced.characters.count, numberOfCharacterPerTextField[i]) - 1)
+            let endIndex = replaced.index(startIndex,
+                                          offsetBy: min(mutableReplaced.characters.count,
+                                                        numberOfCharacterPerTextField[i]) - 1)
+            
             let range = ClosedRange(uncheckedBounds: (lower: startIndex, upper: endIndex))
+            
             textFields[i]?.text = mutableReplaced[range]
             textFields[i]?.becomeFirstResponder()
         
@@ -102,7 +106,10 @@ extension LoginViewController: UITextFieldDelegate, TokenFetcherControllerDelega
     }
     
     private func textFieldContentsAreValid() -> Bool {
-        guard let firstText = firstTextField.text, let numbers = numbersTextField.text, let secondText = secondTextField.text, let _ = Int(numbers)
+        guard let firstText = firstTextField.text,
+            let numbers = numbersTextField.text,
+            let secondText = secondTextField.text,
+            let _ = Int(numbers)
             else { return false }
         return firstText.characters.count == 2 && numbers.characters.count == 2 && secondText.characters.count == 3
     }

--- a/TUM Campus App/LoginViewController.swift
+++ b/TUM Campus App/LoginViewController.swift
@@ -58,7 +58,7 @@ extension LoginViewController: UITextFieldDelegate, TokenFetcherControllerDelega
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let replaced = NSString(string: textField.text ?? "").replacingCharacters(in: range, with: string)
-        let numberOfCharacterPerTextField = [2, 2, 3]
+        let numberOfCharactersPerTextField = [2, 2, 3]
         let textFields = [firstTextField, numbersTextField, secondTextField]
         
         guard let textFieldIndex = textFields.index(where: { $0 == textField })
@@ -78,7 +78,7 @@ extension LoginViewController: UITextFieldDelegate, TokenFetcherControllerDelega
             let startIndex = mutableReplaced.startIndex
             let endIndex = replaced.index(startIndex,
                                           offsetBy: min(mutableReplaced.characters.count,
-                                                        numberOfCharacterPerTextField[i]) - 1)
+                                                        numberOfCharactersPerTextField[i]) - 1)
             
             let range = ClosedRange(uncheckedBounds: (lower: startIndex, upper: endIndex))
             
@@ -89,7 +89,7 @@ extension LoginViewController: UITextFieldDelegate, TokenFetcherControllerDelega
             
             if mutableReplaced.characters.count == 0 {
                 
-                if textFields[i]?.text?.characters.count == numberOfCharacterPerTextField[i] {
+                if textFields[i]?.text?.characters.count == numberOfCharactersPerTextField[i] {
                     textFields[min(textFields.count - 1, i + 1)]?.becomeFirstResponder()
                 }
                 


### PR DESCRIPTION
### Issue

**Steps to reproduce**:
(1):

Open login screen
copy your ID (e.g. ga12ab)
paste the ID in the first textfield
You will see that the whole ID is pasted into one textfield.

(2):

Open login screen
Input the first two characters of your ID and then select the first textfield again
Input another character
You will see that it is possible to input more than the expected two characters into the textfield.

**How this fixes the issue**:

- Specify number of characters fitting into each textfield explicitly
- Use the replacement string's indexes to find out where to put a given character

This fixes the following issue(s): 
#151 