### PR TITLE
Update fastlane snapshot

### DIFF
--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,9 +1,9 @@
 devices([
-  "iPhone 5",
-  "iPhone 6 Plus",
-#  "iPad Pro (12.9 inch)",
-#  "iPad Pro (9.7 inch)",
+	"iPhone 5",
+  	"iPhone 8 Plus",
 ])
+
+ios_version '11.0.1'
 
 languages([
   "de-DE",

--- a/fastlane/SnapshotHelper.swift
+++ b/fastlane/SnapshotHelper.swift
@@ -6,43 +6,84 @@
 //  Copyright © 2015 Felix Krause. All rights reserved.
 //
 
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
 import Foundation
 import XCTest
 
 var deviceLanguage = ""
 var locale = ""
 
-@available(*, deprecated, message: "use setupSnapshot: instead")
-func setLanguage(_ app: XCUIApplication) {
-    setupSnapshot(app)
-}
-
 func setupSnapshot(_ app: XCUIApplication) {
     Snapshot.setupSnapshot(app)
 }
 
-func snapshot(_ name: String, waitForLoadingIndicator: Bool = true) {
-    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        Snapshot.snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+    case cannotDetectUser
+    case cannotFindHomeDirectory
+    case cannotFindSimulatorHomeDirectory
+    case cannotAccessSimulatorHomeDirectory(String)
+
+    var debugDescription: String {
+        switch self {
+        case .cannotDetectUser:
+            return "Couldn't find Snapshot configuration files - can't detect current user "
+        case .cannotFindHomeDirectory:
+            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):
+            return "Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?"
+        }
+    }
 }
 
 open class Snapshot: NSObject {
+    static var app: XCUIApplication!
+    static var cacheDirectory: URL!
+    static var screenshotsDirectory: URL? {
+        return cacheDirectory.appendingPathComponent("screenshots", isDirectory: true)
+    }
 
     open class func setupSnapshot(_ app: XCUIApplication) {
-        setLanguage(app)
-        setLocale(app)
-        setLaunchArguments(app)
+        do {
+            let cacheDir = try pathPrefix()
+            Snapshot.cacheDirectory = cacheDir
+            Snapshot.app = app
+            setLanguage(app)
+            setLocale(app)
+            setLaunchArguments(app)
+        } catch let error {
+            print(error)
+        }
     }
 
     class func setLanguage(_ app: XCUIApplication) {
-        guard let prefix = pathPrefix() else {
-            return
-        }
-
-        let path = prefix.appendingPathComponent("language.txt")
+        let path = cacheDirectory.appendingPathComponent("language.txt")
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
-            deviceLanguage = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue).trimmingCharacters(in: trimCharacterSet) as String
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
             app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
         } catch {
             print("Couldn't detect/set language...")
@@ -50,15 +91,11 @@ open class Snapshot: NSObject {
     }
 
     class func setLocale(_ app: XCUIApplication) {
-        guard let prefix = pathPrefix() else {
-            return
-        }
-
-        let path = prefix.appendingPathComponent("locale.txt")
+        let path = cacheDirectory.appendingPathComponent("locale.txt")
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
-            locale = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue).trimmingCharacters(in: trimCharacterSet) as String
+            locale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
         } catch {
             print("Couldn't detect/set locale...")
         }
@@ -69,15 +106,11 @@ open class Snapshot: NSObject {
     }
 
     class func setLaunchArguments(_ app: XCUIApplication) {
-        guard let prefix = pathPrefix() else {
-            return
-        }
-
-        let path = prefix.appendingPathComponent("snapshot-launch_arguments.txt")
+        let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
         app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
 
         do {
-            let launchArguments = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
             let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
             let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location:0, length:launchArguments.characters.count))
             let results = matches.map { result -> String in
@@ -89,54 +122,124 @@ open class Snapshot: NSObject {
         }
     }
 
-    open class func snapshot(_ name: String, waitForLoadingIndicator: Bool = true) {
-        if waitForLoadingIndicator {
-            waitForLoadingIndicatorToDisappear()
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
         }
 
         print("snapshot: \(name)") // more information about this, check out https://github.com/fastlane/fastlane/tree/master/snapshot#how-does-it-work
 
         sleep(1) // Waiting for the animation to be finished (kind of)
 
-        #if os(tvOS)
-            XCUIApplication().childrenMatchingType(.Browser).count
+        #if os(OSX)
+            XCUIApplication().typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
-            XCUIDevice.shared().orientation = .unknown
+            let screenshot = app.windows.firstMatch.screenshot()
+            guard let simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+            let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+            do {
+                try screenshot.pngRepresentation.write(to: path)
+            } catch let error {
+                print("Problem writing screenshot: \(name) to \(path)")
+                print(error)
+            }
         #endif
     }
 
-    class func waitForLoadingIndicatorToDisappear() {
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
         #if os(tvOS)
             return
         #endif
 
-        let query = XCUIApplication().statusBars.children(matching: .other).element(boundBy: 1).children(matching: .other)
-
-        while (0..<query.count).map({ query.element(boundBy: $0) }).contains(where: { $0.isLoadingIndicator }) {
-            sleep(1)
-            print("Waiting for loading indicator to disappear...")
-        }
+        let networkLoadingIndicator = XCUIApplication().otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
-    class func pathPrefix() -> NSString? {
-        if let path = ProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString? {
-            return path.appendingPathComponent("Library/Caches/tools.fastlane") as NSString?
-        }
-        print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
-        return nil
+    class func pathPrefix() throws -> URL? {
+        let homeDir: URL
+        // on OSX config is stored in /Users/<username>/Library
+        // and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            guard let user = ProcessInfo().environment["USER"] else {
+                throw SnapshotError.cannotDetectUser
+            }
+
+            guard let usersDir =  FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
+                throw SnapshotError.cannotFindHomeDirectory
+            }
+
+            homeDir = usersDir.appendingPathComponent(user)
+        #else
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
+            }
+            guard let homeDirUrl = URL(string: simulatorHostHome) else {
+                throw SnapshotError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
+            }
+            homeDir = URL(fileURLWithPath: homeDirUrl.path)
+        #endif
+        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }
 }
 
-extension XCUIElement {
-    var isLoadingIndicator: Bool {
-        let whiteListedLoaders = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
-        if whiteListedLoaders.contains(self.identifier) {
-            return false
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasWhiteListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasWhiteListedIdentifier: Bool {
+        let whiteListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+        return whiteListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
         }
-        return self.frame.size == CGSize(width: 10, height: 20)
+
+        return self.containing(isNetworkLoadingIndicator)
+    }
+
+    var deviceStatusBars: XCUIElementQuery {
+        let deviceWidth = XCUIApplication().frame.width
+
+        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return self.containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
     }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.2]
+// SnapshotHelperVersion [1.6]


### PR DESCRIPTION
- Update snapshot helper for use with fastlane 2.62.0 (with older versions we have errors with xcode9 / swift4 apparantly)
- Use iPhone 8 as second device

Needed in order to create updated screenshots for the 1.2 release (#169)

(_SnapshotHelper.swift_ is autogenerated by fastlane)