### PR TITLE
Add screenshot for study rooms

### DIFF
--- a/AutomatedScreenshots/AutomatedScreenshots.swift
+++ b/AutomatedScreenshots/AutomatedScreenshots.swift
@@ -34,6 +34,9 @@ class ScreenshotUITests: XCTestCase {
         app.navigationBars.buttons.element(boundBy: 0).tap()
         tablesQuery.staticTexts["My Lectures"].tap()
         snapshot("3_MyLectures")
+        app.navigationBars.buttons.element(boundBy: 0).tap()
+        tablesQuery.staticTexts["Study Rooms"].tap()
+        snapshot("4_StudyRooms")
 //        ToDo: RoomFinder: Wait for callback / results before doing screenshot
 //        app.navigationBars["My Lectures"].buttons["More"].tap()
 //        tablesQuery.staticTexts["Room Finder"].tap()


### PR DESCRIPTION
Closes #169, Closes #173

We now can autogenerate the following set of screenshots:
Note, that the calendar doesn't scroll to the next event but just shows the current time, so depending on when we do the automatic screenshots, it will be empty currently.
![image](https://user-images.githubusercontent.com/3121306/31840310-16628316-b5e5-11e7-9369-902d10e0603f.png)
