### PR TITLE
Fix manual calendar updating

### DIFF
--- a/TUM Campus App/CalendarManager.swift
+++ b/TUM Campus App/CalendarManager.swift
@@ -77,6 +77,7 @@ class CalendarManager: Manager {
     }
     
     func getFromXML(_ value: String, handler: ([DataElement]) -> ()) {
+        CalendarManager.calendarItems.removeAll()
         let data = SWXMLHash.parse(value)
         let events = data["events"]["event"].all
         for event in events {

--- a/TUM Campus App/CalendarViewController.swift
+++ b/TUM Campus App/CalendarViewController.swift
@@ -39,7 +39,6 @@ class CalendarViewController: UIViewController, DetailView {
     }
     
     func updateCalendar(_ sender: AnyObject?) {
-        print("updateCalendar clicked")
         navigationItem.rightBarButtonItems = [stopRefreshBarButton, todayBarButton]
         delegate?.dataManager().updateCalendar(self)
     }
@@ -157,6 +156,7 @@ extension CalendarViewController: TumDataReceiver {
         }
         let now = Date()
         updateTitle(now)
+        dayPlannerView.reloadAllEvents()
         navigationItem.rightBarButtonItems = [refreshBarButton, todayBarButton]
     }
 }


### PR DESCRIPTION
- remove current calendar items from the manager before appending the new ones
- directly update calendar view when we get new data

Fixes #182