### PR TITLE
Update host for SonarCloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.links.ci=https://travis-ci.org/TCA-Team/iOS
 sonar.links.scm=https://github.com/TCA-Team/iOS
 sonar.links.issue=https://github.com/TCA-Team/iOS/issues
 
-sonar.host.url=https://sonarqube.com
+sonar.host.url=https://sonarcloud.io
 # Credentials are stored in environment variables and get passed into the sonar-scanner command by Fastlane
 
 sonar.sources=TUM Campus App/


### PR DESCRIPTION
We got the following mail (to the mail address I registered the project with on sonarqube.com)

> About 6 months ago, we renamed SonarQube.com to SonarCloud. The URL of the service changed from https://sonarqube.com to https://sonarcloud.io.
> 
> I am contacting you because we noticed that you are still using the old URL (sonarqube.com) to point to the service when you run analyses. Typically, this is set through the "sonar.host.url" property in your build scripts, or in your CI tool configuration (like an end-point in VSTS or a global config in Jenkins).
> 
> In a few months, we are going to drop the old URL to keep only https://sonarcloud.io. You probably want to take a look at this early to prevent any futur errors in your build jobs.


Furthermore the following part might be interesting aswell:

> Also, if you are using Travis as your CI engine to trigger the analyses, I suggest that you take a look at our Travis Add-on. Relying on this add-on would allow to not be impacted by potential similar changes in the future.