### PR TITLE
Update News and NewsSource

### DIFF
--- a/TUM Campus App/News.swift
+++ b/TUM Campus App/News.swift
@@ -30,20 +30,6 @@ final class News: DataElement {
     let link: String
     let imageUrl: String?
     
-    /*
-    // In the case of news (not TUFilm movies), the image URL is stored in link.
-    // This computed property returns the appropriate URL depending on availability.
-    var imageUrl: String? {
-        if let image = image, !image.isEmpty {
-            return image
-        } else if link.hasSuffix(".jpeg") {
-            return link
-        } else {
-            return nil
-        }
-    }
-    */
-    
     init(id: String, source: Source, date: Date, title: String, link: String, imageUrl: String? = nil) {
         self.id = id
         self.source = source

--- a/TUM Campus App/News.swift
+++ b/TUM Campus App/News.swift
@@ -28,8 +28,9 @@ final class News: DataElement {
     let date: Date
     let title: String
     let link: String
-    let image: String?
+    let imageUrl: String?
     
+    /*
     // In the case of news (not TUFilm movies), the image URL is stored in link.
     // This computed property returns the appropriate URL depending on availability.
     var imageUrl: String? {
@@ -41,6 +42,7 @@ final class News: DataElement {
             return nil
         }
     }
+    */
     
     init(id: String, source: Source, date: Date, title: String, link: String, imageUrl: String? = nil) {
         self.id = id
@@ -48,7 +50,7 @@ final class News: DataElement {
         self.date = date
         self.title = title
         self.link = link
-        self.image = imageUrl
+        self.imageUrl = imageUrl
     }
     
     var text: String {

--- a/TUM Campus App/NewsSource.swift
+++ b/TUM Campus App/NewsSource.swift
@@ -42,9 +42,6 @@ extension News.Source {
     static let newsspreadFMI = News.Source(identifier: 7)
     static let newsspreadChemistry = News.Source(identifier: 8)
     static let newsspreadSG = News.Source(identifier: 9)
-    static let newsspreadWI = News.Source(identifier: 10)
-    static let newsspreadPhysics = News.Source(identifier: 11)
-    static let newsspreadLab = News.Source(identifier: 12)
     static let newsspreadWeihenstephan = News.Source(identifier: 13)
     static let alumni = News.Source(identifier: 14)
     static let impulsiv = News.Source(identifier: 15)
@@ -55,11 +52,8 @@ extension News.Source {
         .newsspreadFMI,
         .newsspreadChemistry,
         .newsspreadSG,
-        .newsspreadWI,
-        .newsspreadPhysics,
-        .newsspreadLab,
-        .newsspreadWeihenstephan,
-        ]
+        .newsspreadWeihenstephan
+    ]
     
     static var restOfNews: News.Source {
         return News.Source.all.subtracting([.movies, .newsSpread])


### PR DESCRIPTION
The server now returns image URLs of news items under the appropriate key "image". This commit updates the object creation of `News` objects accordingly. It also removes non-existing `NewsSource` objects.