### PR TITLE
Resize TUM logo to more pleasant size

### DIFF
--- a/TUM Campus App/CardViewController.swift
+++ b/TUM Campus App/CardViewController.swift
@@ -110,9 +110,9 @@ class CardViewController: UIViewController, UICollectionViewDelegateFlowLayout, 
         guard let view = nib?.first else { return }
         
         logoView = view
-        view.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        view.frame = CGRect(x: 0, y: 0, width: 100, height: 32)
         view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 32).isActive = true
         self.navigationItem.titleView = view
     }
     

--- a/TUM Campus App/LoginViewController.swift
+++ b/TUM Campus App/LoginViewController.swift
@@ -110,9 +110,9 @@ class LoginViewController: UIViewController {
         let nib = bundle.loadNibNamed("TUMLogoView", owner: nil, options: nil)?.flatMap { $0 as? TUMLogoView }
         guard let view = nib?.first else { return }
         logoView = view
-        view.frame = CGRect(x: 0, y: 0, width: 100, height: 40)
+        view.frame = CGRect(x: 0, y: 0, width: 100, height: 32)
         view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 32).isActive = true
         self.navigationItem.titleView = view
     }
 }

--- a/TUM Campus App/Setup.storyboard
+++ b/TUM Campus App/Setup.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>


### PR DESCRIPTION
The TUM logo in the NavigationBar is oversized. I’ve adjusted it to a more pleasant size. 

Old: 
![simulator screen shot - iphone 7 plus - 2018-06-15 at 17 39 27](https://user-images.githubusercontent.com/11819826/41477170-c766994c-70c3-11e8-9d4b-37ca82a24f9a.png)

New
![simulator screen shot - iphone 7 plus - 2018-06-15 at 17 38 58](https://user-images.githubusercontent.com/11819826/41477177-ccfc1df0-70c3-11e8-8c4e-d510098e8314.png)
