### PR TITLE
Filter newspread items from news card

### DIFF
--- a/TUM Campus App/DataSources/NewsDataSource.swift
+++ b/TUM Campus App/DataSources/NewsDataSource.swift
@@ -41,7 +41,8 @@ class NewsDataSource: NSObject, TUMDataSource {
     func refresh(group: DispatchGroup) {
         group.enter()
         manager.fetch().onSuccess(in: .main) { data in
-            self.data = data.filter { $0.source != News.Source.movies }
+            self.data = data
+                .filter { $0.source != News.Source.movies && $0.source != News.Source.newsSpread }
             group.leave()
         }
     }


### PR DESCRIPTION
This commit filters newspread from the news card. Newspread items are now only displayed in the newspread cards.