### PR TITLE
Fix empty study rooms list

### DIFF
--- a/TUM Campus App/DataSources/StudyRoomsDataSource.swift
+++ b/TUM Campus App/DataSources/StudyRoomsDataSource.swift
@@ -60,7 +60,7 @@ class StudyRoomsDataSource: NSObject, TUMDataSource, TUMInteractiveDataSource {
         if let destination = storyboard.instantiateInitialViewController() as? StudyRoomsTableViewController {
             destination.delegate = parent
             destination.roomGroups = data
-            destination.currentGroup = currentGroup
+            destination.currentGroup = currentGroup ?? data.first
             parent.navigationController?.pushViewController(destination, animated: true)
         }
     }


### PR DESCRIPTION
This commit changes a bug where the study rooms list would stay empty when opened via the “Show more” button in `CardViewController`.