### PR TITLE
Properly add Crashlytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,8 @@ target 'Campus' do
     pod 'Kanna', '~> 4.0.0'
 	pod 'Kingfisher', '~> 4.0'
 	pod 'Firebase', '~> 5.2'
+	pod 'Fabric', '~> 1.7.7'
+	pod 'Crashlytics', '~> 3.10.2'
     
     target 'TUM Campus AppUITests' do
         inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,6 +3,9 @@ PODS:
   - CalendarLib (2.0):
     - OrderedDictionary (~> 1.2)
     - OSCache (~> 1.2)
+  - Crashlytics (3.10.2):
+    - Fabric (~> 1.7.7)
+  - Fabric (1.7.7)
   - Firebase (5.2.0):
     - Firebase/Core (= 5.2.0)
   - Firebase/Core (5.2.0):
@@ -40,6 +43,8 @@ PODS:
 DEPENDENCIES:
   - ASWeekSelectorView (~> 1.0)
   - CalendarLib (~> 2.0)
+  - Crashlytics (~> 3.10.2)
+  - Fabric (~> 1.7.7)
   - Firebase (~> 5.2)
   - Fuzzi (~> 0.1.1)
   - Kanna (~> 4.0.0)
@@ -53,6 +58,8 @@ SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - ASWeekSelectorView
     - CalendarLib
+    - Crashlytics
+    - Fabric
     - Firebase
     - FirebaseAnalytics
     - FirebaseCore
@@ -90,6 +97,8 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   ASWeekSelectorView: 396acc65f14aa09441528fbd0b2ec46989d8cb4a
   CalendarLib: 040a8a655376581d8dc7c3c63196ddcf5223f471
+  Crashlytics: 0360624eea1c978a743feddb2fb1ef8b37fb7a0d
+  Fabric: bda89e242bce1b7b8ab264248cf3407774ce0095
   Firebase: 25ed0412036d7d008568d1fb4d2e9d81ea8a0a2c
   FirebaseAnalytics: b3628aea54c50464c32c393fb2ea032566e7ecc2
   FirebaseCore: a3c87242451633fff8490183898075ce77d168d2
@@ -106,6 +115,6 @@ SPEC CHECKSUMS:
   SWXMLHash: 3c39a53723202800e9e1a87f14b2fe7ac1da98ec
   TKSubmitTransition: 647b907508da58ba864141e3c4382442ec536d40
 
-PODFILE CHECKSUM: 1d0029baca529433948077fcbc05a2af4c8a966d
+PODFILE CHECKSUM: 91d31162e06e46f2d2bf4acc5b0ea5f013a55db7
 
 COCOAPODS: 1.5.0

--- a/TUM Campus App.xcodeproj/project.pbxproj
+++ b/TUM Campus App.xcodeproj/project.pbxproj
@@ -1355,7 +1355,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Fabric/run\"";
+			shellScript = "releaseConfig=\"Release\"\n\nif [ \"$releaseConfig\" = \"${CONFIGURATION}\" ]; then\n    echo \"Running Crashlytics\"\n    \"${PODS_ROOT}/Fabric/run\"\nfi";
 		};
 		C515922059C2A6B2F17CB370 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1747,7 +1747,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Campus.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = LQ83GZ8GRK;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "TUM Campus App/Info.plist";

--- a/TUM Campus App.xcodeproj/project.pbxproj
+++ b/TUM Campus App.xcodeproj/project.pbxproj
@@ -1086,6 +1086,7 @@
 				0E424F421BE16DBD00B5DFCB /* Frameworks */,
 				0E424F431BE16DBD00B5DFCB /* Resources */,
 				8D8C5F282F14F0418556891A /* [CP] Embed Pods Frameworks */,
+				9DE731D520EF8B8100C896FC /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1342,6 +1343,19 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Campus/Pods-Campus-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		9DE731D520EF8B8100C896FC /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Fabric/run\"";
 		};
 		C515922059C2A6B2F17CB370 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1733,6 +1747,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Campus.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = LQ83GZ8GRK;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "TUM Campus App/Info.plist";

--- a/TUM Campus App/AppDelegate.swift
+++ b/TUM Campus App/AppDelegate.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 import Firebase
+import Crashlytics
+import Fabric
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -18,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         initFirebase()
         setupAppearance()
         conditionallyShowLoginViewController()
-
         return true
     }
     


### PR DESCRIPTION
Turns out Crashlytics is not enabled by just including Firebase in the project. This commit therefore adds Crashlytics and Fabric explicitly. However, we likely only want crash reports for release builds, so I’ve configured it accordingly.