### PR TITLE
Allow toggling between the default logo and the pride version

### DIFF
--- a/TUM Campus App/TUMLogoView.swift
+++ b/TUM Campus App/TUMLogoView.swift
@@ -22,15 +22,17 @@ import UIKit
 
 
 class TUMLogoView: UIView {
+    private static let defaultLogo = #imageLiteral(resourceName: "logo-blue")
+    private static let rainbowLogo = #imageLiteral(resourceName: "logo-rainbow")
     
     @IBOutlet weak var imageView: UIImageView!
     
-    @IBAction func tumLogoTap(sender: AnyObject) {
-        imageView.image = #imageLiteral(resourceName: "logo-rainbow")
+    @objc private func toggleLogo() {
+        imageView.image = imageView.image == TUMLogoView.defaultLogo ? TUMLogoView.rainbowLogo : TUMLogoView.defaultLogo
     }
     
     override func awakeFromNib() {
-        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tumLogoTap(sender:)))
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(toggleLogo))
         gestureRecognizer.numberOfTapsRequired = 3
         addGestureRecognizer(gestureRecognizer)
     }


### PR DESCRIPTION
This also:
- renames `tumLogoTap(sender:)` to `toggleLogo` and removes the unused `sender` argument
- removes the `@IBAction` attribute in favor of `@objc` (allowing us to make the method private)

tbh i'm not really sold on the logo switching code but i guess that's nicer than introducing some additional property to keep track of which version of the logo is currently being displayed