### PR TITLE
Update brew to fix travis build error

### DIFF
--- a/fastlane/before_install.sh
+++ b/fastlane/before_install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 sudo gem install slather
 
+brew update # can be removed if travis updated their machine image to include brew list with new sonar-scanner binaries
 brew install swiftlint
 brew install sonar-scanner


### PR DESCRIPTION
### Issue
<!-- Short description of the issue and how this fixes the issue -->

This fixes the following issue(s): 
Currently, all builds are failing, because the url to the sonar-scanner binaries [changed](https://github.com/Homebrew/homebrew-core/commit/57b804fcc5d5e776c2f5ccd8a79c626b5e743928). The image used by travis uses brew formulas that don't include the above-mentioned change. 

To fix the build errors, I temporarily added a `brew update` statement that can be removed as soon as travis updated their images.
